### PR TITLE
Setup publishing for Gradle Plugin targets

### DIFF
--- a/build-logic/src/main/kotlin/publish.gradle.kts
+++ b/build-logic/src/main/kotlin/publish.gradle.kts
@@ -30,7 +30,8 @@ publishing {
     }
   }
 
-  if (!plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")) {
+  // We don't want to create pubblications for KMP and Gradle Plugin targets
+  if (plugins.hasPlugin("org.jetbrains.kotlin.jvm") && name != "gradleplugin") {
     publications.register<MavenPublication>("DcgPublication") {
       from(components["java"])
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,3 +35,13 @@ subprojects {
     }
   }
 }
+
+tasks.register("publishAllToMavenLocal") {
+  description = "Publish all the artifacts to be available inside Maven Local"
+  dependsOn(gradle.includedBuild("gradleplugin").task(":publishToMavenLocal"))
+  subprojects.forEach {
+    if (it.project.plugins.hasPlugin("publish")) {
+      dependsOn(it.tasks.named("publishToMavenLocal"))
+    }
+  }
+}

--- a/gradleplugin/build.gradle.kts
+++ b/gradleplugin/build.gradle.kts
@@ -10,6 +10,7 @@ import java.util.*
 plugins {
   alias(libs.plugins.kotlin)
   id("java-gradle-plugin")
+  id("publish")
 }
 
 dependencies {

--- a/gradleplugin/settings.gradle.kts
+++ b/gradleplugin/settings.gradle.kts
@@ -23,3 +23,5 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "gradleplugin"
+
+includeBuild("../build-logic")


### PR DESCRIPTION
This sits on top of #11

Here I configure publishing for the Gradle Plugin targets so we get both the plugin and the marker published correctly.

I've also created a top level `publishAllToMavenLocal` task so it's easier to iterate on the publshing

That's the output of what gets published locally:

```
/Users/ncor/.m2/repository/com/facebook
└── kotlin
    └── compilerplugins
        └── dataclassgenerate
            ├── annotation
            │   ├── 1.0.0
            │   │   ├── annotation-1.0.0-kotlin-tooling-metadata.json
            │   │   ├── annotation-1.0.0-sources.jar
            │   │   ├── annotation-1.0.0.jar
            │   │   ├── annotation-1.0.0.module
            │   │   └── annotation-1.0.0.pom
            │   └── maven-metadata-local.xml
            ├── annotation-jvm
            │   ├── 1.0.0
            │   │   ├── annotation-jvm-1.0.0-sources.jar
            │   │   ├── annotation-jvm-1.0.0.jar
            │   │   ├── annotation-jvm-1.0.0.module
            │   │   └── annotation-jvm-1.0.0.pom
            │   └── maven-metadata-local.xml
            ├── cli
            │   ├── 1.0.0
            │   │   ├── cli-1.0.0-javadoc.jar
            │   │   ├── cli-1.0.0-sources.jar
            │   │   ├── cli-1.0.0.jar
            │   │   ├── cli-1.0.0.module
            │   │   └── cli-1.0.0.pom
            │   └── maven-metadata-local.xml
            ├── com.facebook.kotlin.compilerplugins.dataclassgenerate.gradle.plugin
            │   ├── 1.0.0
            │   │   └── com.facebook.kotlin.compilerplugins.dataclassgenerate.gradle.plugin-1.0.0.pom
            │   └── maven-metadata-local.xml
            ├── common
            │   ├── 1.0.0
            │   │   ├── common-1.0.0-javadoc.jar
            │   │   ├── common-1.0.0-sources.jar
            │   │   ├── common-1.0.0.jar
            │   │   ├── common-1.0.0.module
            │   │   └── common-1.0.0.pom
            │   └── maven-metadata-local.xml
            ├── gradleplugin
            │   ├── 1.0.0
            │   │   ├── gradleplugin-1.0.0.jar
            │   │   ├── gradleplugin-1.0.0.module
            │   │   └── gradleplugin-1.0.0.pom
            │   └── maven-metadata-local.xml
            ├── k1
            │   ├── 1.0.0
            │   │   ├── k1-1.0.0-javadoc.jar
            │   │   ├── k1-1.0.0-sources.jar
            │   │   ├── k1-1.0.0.jar
            │   │   ├── k1-1.0.0.module
            │   │   └── k1-1.0.0.pom
            │   └── maven-metadata-local.xml
            ├── k2
            │   ├── 1.0.0
            │   │   ├── k2-1.0.0-javadoc.jar
            │   │   ├── k2-1.0.0-sources.jar
            │   │   ├── k2-1.0.0.jar
            │   │   ├── k2-1.0.0.module
            │   │   └── k2-1.0.0.pom
            │   └── maven-metadata-local.xml
            ├── superclass
            │   ├── 1.0.0
            │   │   ├── superclass-1.0.0-kotlin-tooling-metadata.json
            │   │   ├── superclass-1.0.0-sources.jar
            │   │   ├── superclass-1.0.0.jar
            │   │   ├── superclass-1.0.0.module
            │   │   └── superclass-1.0.0.pom
            │   └── maven-metadata-local.xml
            └── superclass-jvm
                ├── 1.0.0
                │   ├── superclass-jvm-1.0.0-sources.jar
                │   ├── superclass-jvm-1.0.0.jar
                │   ├── superclass-jvm-1.0.0.module
                │   └── superclass-jvm-1.0.0.pom
                └── maven-metadata-local.xml

23 directories, 52 files
```