### PR TITLE
Automate publishing of stable artifacts with Github Actions

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,59 @@
+name: Publish Release
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git Tag or Ref to publish from. Default to main, but you can specify a tag to retrigger publishing"
+        required: true
+        default: 'main'
+
+jobs:
+  publish:
+    if: ${{ github.repository == 'facebookincubator/dataclassgenerate'}}
+    runs-on: [ubuntu-latest]
+    env:
+      GRADLE_OPTS: -Dorg.gradle.parallel=false
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Configure JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+      - name: Cache Gradle Caches
+        uses: gradle/gradle-build-action@v2
+
+      - name: Publish to Maven Local
+        run: ./gradlew publishAllToMavenLocal
+        env:
+          ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
+
+      - name: Upload Build Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: 'snapshot-artifacts'
+          path: '~/.m2/repository/'
+
+      - name: Publish the Artifact to Maven Central
+        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+        env:
+          ORG_GRADLE_PROJECT_NEXUS_USERNAME: ${{ secrets.ORG_GRADLE_PROJECT_NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_NEXUS_PASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
+
+      - name: Publish the Gradle Plugin to Maven Central
+        run: ./gradlew -p gradleplugin publishPlugins
+        env:
+          ORG_GRADLE_PROJECT_gradle.publish.key: ${{ secrets.ORG_GRADLE_PROJECT_GRADLE_PUBLISH_KEY }}
+          ORG_GRADLE_PROJECT_gradle.publish.secret: ${{ secrets.ORG_GRADLE_PROJECT_GRADLE_PUBLISH_SECRET }}
+          ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   publish:
-    # remove this check when your secrets are setup and you're ready to publish
     if: ${{ github.repository == 'facebookincubator/dataclassgenerate'}}
     runs-on: [ubuntu-latest]
     env:

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -36,7 +36,7 @@ jobs:
           path: '~/.m2/repository/'
 
       - name: Publish to the Snapshot Repository
-        run: ./gradlew publishAllToSnapshotRepository
+        run: ./gradlew publishAllToSonatype
         env:
           ORG_GRADLE_PROJECT_NEXUS_USERNAME: ${{ secrets.ORG_GRADLE_PROJECT_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_NEXUS_PASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_NEXUS_PASSWORD }}

--- a/build-logic/src/main/kotlin/publish.gradle.kts
+++ b/build-logic/src/main/kotlin/publish.gradle.kts
@@ -10,26 +10,13 @@ plugins {
   id("signing")
 }
 
-publishing {
-  repositories {
-    maven {
-      name = "mavenCentral"
-      url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2")
-      credentials {
-        username = "NEXUS_USERNAME".byProperty
-        password = "NEXUS_PASSWORD".byProperty
-      }
-    }
-    maven {
-      name = "sonatypeSnapshot"
-      url = uri("https://oss.sonatype.org/content/repositories/snapshots")
-      credentials {
-        username = "NEXUS_USERNAME".byProperty
-        password = "NEXUS_PASSWORD".byProperty
-      }
-    }
-  }
+if (!"USE_SNAPSHOT".byProperty.isNullOrBlank()) {
+  version = "$VERSION_NAME-SNAPSHOT"
+} else {
+  version = VERSION_NAME
+}
 
+publishing {
   // We don't want to create pubblications for KMP and Gradle Plugin targets
   if (plugins.hasPlugin("org.jetbrains.kotlin.jvm") && name != "gradleplugin") {
     publications.register<MavenPublication>("DcgPublication") { from(components["java"]) }
@@ -38,11 +25,6 @@ publishing {
   publications.withType(MavenPublication::class) {
     groupId = "com.facebook.kotlin.compilerplugins.dataclassgenerate"
     artifactId = project.name
-    if (!"USE_SNAPSHOT".byProperty.isNullOrBlank()) {
-      version = "$VERSION_NAME-SNAPSHOT"
-    } else {
-      version = VERSION_NAME
-    }
     pom {
       description.set(
           "A Kotlin compiler plugin that addresses an Android APK size overhead from Kotlin data classes.")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,19 @@ plugins {
   alias(libs.plugins.kotlin.android) apply false
   alias(libs.plugins.kotlin.serialization) apply false
   alias(libs.plugins.android.library) apply false
+  alias(libs.plugins.publish.plugin)
+}
+
+val nexusUsername = findProperty("NEXUS_USERNAME")?.toString()
+val nexusPassword = findProperty("NEXUS_PASSWORD")?.toString()
+
+nexusPublishing {
+  repositories {
+    sonatype {
+      username.set(nexusUsername)
+      password.set(nexusPassword)
+    }
+  }
 }
 
 subprojects {
@@ -46,15 +59,13 @@ tasks.register("publishAllToMavenLocal") {
   }
 }
 
-tasks.register("publishAllToSnapshotRepository") {
-  description = "Publish all the artifacts to be available as Snapshots on Sonatype"
-  dependsOn(
-      gradle
-          .includedBuild("gradleplugin")
-          .task(":publishAllPublicationsToSonatypeSnapshotRepository"))
+tasks.register("publishAllToSonatype") {
+  description =
+      "Publish all the artifacts to be available on Sonatype (either Maven Central or Snapshot Repository)"
+  dependsOn(gradle.includedBuild("gradleplugin").task(":publishToSonatype"))
   subprojects.forEach {
     if (it.project.plugins.hasPlugin("publish")) {
-      dependsOn(it.tasks.named("publishAllPublicationsToSonatypeSnapshotRepository"))
+      dependsOn(it.tasks.named("publishToSonatype"))
     }
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,12 +16,14 @@ mockito-kotlin = "2.2.11"
 assertj-core = "2.9.0"
 junit = "4.12"
 robolectric = "4.9"
+publish-plugin = "1.1.0"
 
 [plugins]
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin"}
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin"}
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin"}
 android-library= { id = "com.android.library", version.ref = "agp"}
+publish-plugin = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "publish-plugin"}
 
 [libraries]
 kotlin-compilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }

--- a/gradleplugin/build.gradle.kts
+++ b/gradleplugin/build.gradle.kts
@@ -12,6 +12,8 @@ plugins {
   id("publish")
 }
 
+group = "com.facebook.kotlin.compilerplugins.dataclassgenerate"
+
 val nexusUsername = findProperty("NEXUS_USERNAME")?.toString()
 val nexusPassword = findProperty("NEXUS_PASSWORD")?.toString()
 
@@ -30,6 +32,8 @@ dependencies {
 }
 
 gradlePlugin {
+  website.set("https://github.com/facebookincubator/dataclassgenerate")
+  vcsUrl.set("https://github.com/facebookincubator/dataclassgenerate")
   plugins {
     create("dataClassGeneratePlugin") {
       id = "com.facebook.kotlin.compilerplugins.dataclassgenerate"

--- a/gradleplugin/build.gradle.kts
+++ b/gradleplugin/build.gradle.kts
@@ -7,8 +7,21 @@
 
 plugins {
   alias(libs.plugins.kotlin)
+  alias(libs.plugins.publish.plugin)
   id("java-gradle-plugin")
   id("publish")
+}
+
+val nexusUsername = findProperty("NEXUS_USERNAME")?.toString()
+val nexusPassword = findProperty("NEXUS_PASSWORD")?.toString()
+
+nexusPublishing {
+  repositories {
+    sonatype {
+      username.set(nexusUsername)
+      password.set(nexusPassword)
+    }
+  }
 }
 
 dependencies {


### PR DESCRIPTION
Summary:
This commit creates a Publish Release Github Actions Workflow that takes care
of:
1. Publishing all the artifacts to Maven Central
2. Publishing the Gradle Plugin to Maven Central
3. Publishing the Gradle Plugin to Gradle Portal.

The workflow executes whenever a `v*` tag is published AND can be retriggered
manually from any SHA if you need to re-publish a given version.

Reviewed By: zielinskimz

Differential Revision: D44743247

