### PR TITLE
Correclty use javax.inject.Inject inside DCG Gradle Plugin

### DIFF
--- a/gradleplugin/src/main/kotlin/com/facebook/kotlin/compilerplugins/dataclassgenerate/gradle/DataClassGeneratePluginExtension.kt
+++ b/gradleplugin/src/main/kotlin/com/facebook/kotlin/compilerplugins/dataclassgenerate/gradle/DataClassGeneratePluginExtension.kt
@@ -7,7 +7,7 @@
 
 package com.facebook.kotlin.compilerplugins.dataclassgenerate.gradle
 
-import com.facebook.ultralight.Inject
+import javax.inject.Inject
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 


### PR DESCRIPTION
Summary:
Ultralight is not available in OSS. Changing this import inside D73853686 causes the OSS ci of DCG
to fail. We'll have to revert back to an import that is available in OSS.

Differential Revision: D77933413


