### PR TITLE
Migrate DCG to Central Publishing

### DIFF
--- a/build-logic/src/main/kotlin/publish.gradle.kts
+++ b/build-logic/src/main/kotlin/publish.gradle.kts
@@ -19,7 +19,7 @@ if (!"USE_SNAPSHOT".byProperty.isNullOrBlank()) {
 }
 
 publishing {
-  // We don't want to create pubblications for KMP and Gradle Plugin targets
+  // We don't want to create publications for KMP and Gradle Plugin targets
   if (plugins.hasPlugin("org.jetbrains.kotlin.jvm") && name != "gradleplugin") {
     publications.register<MavenPublication>("DcgPublication") { from(components["java"]) }
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,8 @@ nexusPublishing {
     sonatype {
       username.set(nexusUsername)
       password.set(nexusPassword)
+      nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+      snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
     }
   }
 }


### PR DESCRIPTION
Snapshots are currently failing due to OSSRH being sunset on Jun 30th 2025:
https://central.sonatype.org/pages/ossrh-eol/

This migrates the project to Central Publishing which should restore the snapshot publishing.