### PR TITLE
Migrate DCG to Central Publishing - Part 2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ mockito-kotlin = "2.2.11"
 assertj-core = "2.9.0"
 junit = "4.13.2"
 robolectric = "4.9"
-nexus-publish-plugin = "1.1.0"
+nexus-publish-plugin = "2.0.0"
 gradle-publish-plugin = "1.2.0"
 
 [plugins]

--- a/gradleplugin/build.gradle.kts
+++ b/gradleplugin/build.gradle.kts
@@ -23,6 +23,8 @@ nexusPublishing {
     sonatype {
       username.set(nexusUsername)
       password.set(nexusPassword)
+      nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+      snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
     }
   }
 }


### PR DESCRIPTION
We also need to migrate the `gradleplugin` to Central Publishing as otherwise the snapshot will keep on failing publishing.

I'm also bumping the nexus publish plugin to 2.0.0 to keep it up to date.