### PR TITLE
Update to K2.4.0 dropping K1 support

### DIFF
--- a/compiler/cli/build.gradle.kts
+++ b/compiler/cli/build.gradle.kts
@@ -22,7 +22,6 @@ sourceSets { main { resources { setSrcDirs(listOf("resources")) } } }
 
 dependencies {
   implementation(project(":compiler:common"))
-  implementation(project(":compiler:k1"))
   implementation(project(":compiler:k2"))
   compileOnly(libs.kotlin.compilerEmbeddable)
 

--- a/compiler/cli/src/main/kotlin/com/facebook/kotlin/compilerplugins/dataclassgenerate/DataClassGenerateComponentRegistrar.kt
+++ b/compiler/cli/src/main/kotlin/com/facebook/kotlin/compilerplugins/dataclassgenerate/DataClassGenerateComponentRegistrar.kt
@@ -5,9 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// TODO: resolve deprecation errors in DataClassGenerateInterceptorExtension T161233385
-@file:Suppress("DEPRECATION_ERROR")
-
 package com.facebook.kotlin.compilerplugins.dataclassgenerate
 
 import com.facebook.kotlin.compilerplugins.dataclassgenerate.configuration.CompilerConfigurationProperties.ENABLED
@@ -15,7 +12,7 @@ import com.facebook.kotlin.compilerplugins.dataclassgenerate.configuration.Compi
 import com.facebook.kotlin.compilerplugins.dataclassgenerate.configuration.CompilerConfigurationProperties.MODE
 import com.facebook.kotlin.compilerplugins.dataclassgenerate.configuration.DataClassGenerateExt
 import com.facebook.kotlin.compilerplugins.dataclassgenerate.configuration.get
-import org.jetbrains.kotlin.codegen.extensions.ClassBuilderInterceptorExtension
+import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.config.CompilerConfiguration
 
 @OptIn(org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi::class)
@@ -23,15 +20,12 @@ class DataClassGenerateComponentRegistrar : DataClassGenerateComponentRegistrarB
 
   override val supportsK2: Boolean = true
 
-  // Only possible once we have min Kotlin version as 2.3.0
-  // override val pluginId: String = "com.facebook.kotlin.dataclassgenerate"
-
   override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
     if (configuration[ENABLED]) {
       DataClassGenerateExt.generateSuperClass = configuration[GENERATE_SUPER_CLASS]
 
-      ClassBuilderInterceptorExtension.registerExtension(
-          DataClassGenerateInterceptorExtension(configuration[MODE]),
+      IrGenerationExtension.registerExtension(
+          DataClassGenerateIrGenerationExtension(configuration[MODE]),
       )
     }
   }

--- a/compiler/common/src/main/kotlin/com/facebook/kotlin/compilerplugins/dataclassgenerate/configuration/CompilerConfigurationProperty.kt
+++ b/compiler/common/src/main/kotlin/com/facebook/kotlin/compilerplugins/dataclassgenerate/configuration/CompilerConfigurationProperty.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.compiler.plugin.CliOption
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.CompilerConfigurationKey
 
-class CompilerConfigurationProperty<T>(
+class CompilerConfigurationProperty<T : Any>(
     val cliOption: CliOption,
     val configurationKey: CompilerConfigurationKey<T>,
     val default: T?,
@@ -21,6 +21,6 @@ class CompilerConfigurationProperty<T>(
   }
 }
 
-operator fun <T> CompilerConfiguration.get(property: CompilerConfigurationProperty<T>): T =
+operator fun <T : Any> CompilerConfiguration.get(property: CompilerConfigurationProperty<T>): T =
     if (property.default != null) get(property.configurationKey, property.default)
     else get(property.configurationKey)!!

--- a/compiler/common/src/main/kotlin/com/facebook/kotlin/compilerplugins/dataclassgenerate/configuration/StrictMode.kt
+++ b/compiler/common/src/main/kotlin/com/facebook/kotlin/compilerplugins/dataclassgenerate/configuration/StrictMode.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.kotlin.compilerplugins.dataclassgenerate.configuration
+
+import org.jetbrains.kotlin.name.FqName
+
+class DataClassGenerateStrictModeViolationException(message: String) : RuntimeException(message)
+
+fun generateStrictModeViolationMessage(fqName: FqName?): String {
+  val shortName = fqName?.shortName() ?: fqName
+  return """
+     You are running DataClassGenerate compiler plugin in a STRICT mode, but $fqName is not annotated with @DataClassGenerate.
+
+     Replace $shortName with @DataClassGenerate(toString=Mode.OMIT, equalsHashCode=Mode.KEEP)
+     - If $shortName does not need a `toString()` method use `toString=Mode.OMIT`
+     - If $shortName does not need `equals()` and hashCode()` use `equalsHashCode=Mode.OMIT` or
+     consider replacing it with a regular class.
+
+     Read more:
+     1. What is DataClassGenerate? - https://fburl.com/dataclassgenerate_wiki
+     2. How to configure @DataClassGenerate annotation? - https://fburl.com/dataclassgenerate
+     3. What is STRICT mode? - https://fburl.com/dataclassgenerate_mode
+    """
+      .trimIndent()
+}

--- a/compiler/k2/src/main/kotlin/com/facebook/kotlin/compilerplugins/dataclassgenerate/DataClassGenerateIrGenerationExtension.kt
+++ b/compiler/k2/src/main/kotlin/com/facebook/kotlin/compilerplugins/dataclassgenerate/DataClassGenerateIrGenerationExtension.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.kotlin.compilerplugins.dataclassgenerate
+
+import com.facebook.kotlin.compilerplugins.dataclassgenerate.annotation.Mode
+import com.facebook.kotlin.compilerplugins.dataclassgenerate.configuration.DataClassGenerateStrictModeViolationException
+import com.facebook.kotlin.compilerplugins.dataclassgenerate.configuration.PluginMode
+import com.facebook.kotlin.compilerplugins.dataclassgenerate.configuration.generateStrictModeViolationMessage
+import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
+import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
+import org.jetbrains.kotlin.ir.IrStatement
+import org.jetbrains.kotlin.ir.builders.irBlockBody
+import org.jetbrains.kotlin.ir.builders.irCall
+import org.jetbrains.kotlin.ir.builders.irGet
+import org.jetbrains.kotlin.ir.builders.irReturn
+import org.jetbrains.kotlin.ir.declarations.IrClass
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
+import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
+import org.jetbrains.kotlin.ir.declarations.IrParameterKind
+import org.jetbrains.kotlin.ir.declarations.IrSimpleFunction
+import org.jetbrains.kotlin.ir.expressions.IrGetEnumValue
+import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
+import org.jetbrains.kotlin.ir.types.classOrNull
+import org.jetbrains.kotlin.ir.util.classId
+import org.jetbrains.kotlin.ir.util.functions
+import org.jetbrains.kotlin.ir.util.parentAsClass
+import org.jetbrains.kotlin.ir.visitors.IrElementTransformerVoid
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+
+class DataClassGenerateIrGenerationExtension(
+    private val mode: PluginMode,
+) : IrGenerationExtension {
+
+  override fun generate(moduleFragment: IrModuleFragment, pluginContext: IrPluginContext) {
+    moduleFragment.transform(DataClassGenerateTransformer(pluginContext, mode), null)
+  }
+}
+
+private val ANNOTATION_CLASS_ID =
+    ClassId.topLevel(
+        FqName(
+            "com.facebook.kotlin.compilerplugins.dataclassgenerate.annotation.DataClassGenerate"))
+
+private class DataClassGenerateTransformer(
+    private val pluginContext: IrPluginContext,
+    private val mode: PluginMode,
+) : IrElementTransformerVoid() {
+
+  @OptIn(UnsafeDuringIrConstructionAPI::class)
+  override fun visitClass(declaration: IrClass): IrStatement {
+    if (!declaration.isData) return super.visitClass(declaration)
+
+    val annotation =
+        declaration.annotations.firstOrNull {
+          it.symbol.owner.parentAsClass.classId == ANNOTATION_CLASS_ID
+        }
+
+    if (mode == PluginMode.STRICT && annotation == null) {
+      throw DataClassGenerateStrictModeViolationException(
+          generateStrictModeViolationMessage(declaration.classId?.asSingleFqName()))
+    }
+
+    val shouldProcess = annotation != null || mode == PluginMode.IMPLICIT
+
+    if (shouldProcess) {
+      val toStringMode = annotation?.getEnumArgMode("toString_uniqueJvmName") ?: Mode.OMIT
+      val equalsHashCodeMode = annotation?.getEnumArgMode("equalsHashCode") ?: Mode.KEEP
+
+      for (function in declaration.functions.toList()) {
+        if (function.origin != IrDeclarationOrigin.GENERATED_DATA_CLASS_MEMBER) continue
+
+        when (function.name.asString()) {
+          "toString" -> {
+            if (toStringMode == Mode.OMIT) replaceWithSuperCall(function)
+          }
+          "equals" -> {
+            if (equalsHashCodeMode == Mode.OMIT) replaceWithSuperCall(function)
+          }
+          "hashCode" -> {
+            if (equalsHashCodeMode == Mode.OMIT) replaceWithSuperCall(function)
+          }
+        }
+      }
+    }
+
+    return super.visitClass(declaration)
+  }
+
+  @OptIn(UnsafeDuringIrConstructionAPI::class)
+  private fun replaceWithSuperCall(function: IrSimpleFunction) {
+    val parentClass = function.parentAsClass
+    val superClass = parentClass.superTypes.firstOrNull()?.classOrNull?.owner ?: return
+    val regularParams = function.parameters.filter { it.kind == IrParameterKind.Regular }
+    val superFunction =
+        superClass.functions.firstOrNull { candidate ->
+          candidate.name == function.name &&
+              candidate.parameters.count { it.kind == IrParameterKind.Regular } ==
+                  regularParams.size
+        }
+            ?: return
+
+    val builder = DeclarationIrBuilder(pluginContext, function.symbol)
+    function.body =
+        builder.irBlockBody {
+          val call =
+              irCall(superFunction.symbol, function.returnType).apply {
+                superQualifierSymbol = superClass.symbol
+                function.parameters.forEachIndexed { index, param ->
+                  arguments[index] = irGet(param)
+                }
+              }
+          +irReturn(call)
+        }
+  }
+
+  @OptIn(UnsafeDuringIrConstructionAPI::class)
+  private fun org.jetbrains.kotlin.ir.expressions.IrConstructorCall.getEnumArgMode(
+      name: String
+  ): Mode? {
+    val constructor = symbol.owner
+    val paramIndex =
+        constructor.parameters.indexOfFirst {
+          it.kind == IrParameterKind.Regular && it.name == Name.identifier(name)
+        }
+    if (paramIndex < 0) return null
+    val arg = arguments.getOrNull(paramIndex) ?: return null
+    val enumEntry = (arg as? IrGetEnumValue) ?: return null
+    return when (enumEntry.symbol.owner.name.asString()) {
+      "KEEP" -> Mode.KEEP
+      "OMIT" -> Mode.OMIT
+      else -> null
+    }
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@
 #
 
 [versions]
-kotlin = "2.3.20"
+kotlin = "2.4.0"
 agp = "8.7.3"
 byte-buddy-agent = "1.12.18"
 ow2-asm = "9.4"


### PR DESCRIPTION
The current plugin is incompatible with K2.4.0 as its using k1.9 language features. 

From https://kotlinlang.org/docs/whatsnew24.html#breaking-changes-and-deprecations
> Starting with Kotlin 2.4.0, the compiler no longer supports -language-version=1.9. As a result, the K1 compiler is no longer supported.